### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.0.6] - 2023-12-05
 
 ### Changed

--- a/helm/exception-recommender/values.yaml
+++ b/helm/exception-recommender/values.yaml
@@ -3,7 +3,7 @@ serviceType: managed
 
 global:
   image:
-    registry: "docker.io"
+    registry: "gsoci.azurecr.io"
   # Install PSPs
   podSecurityStandards:
     enforced: false
@@ -15,7 +15,7 @@ ciliumNetworkPolicy:
   enabled: true
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/exception-recommender
   pullPolicy: IfNotPresent
 
@@ -52,7 +52,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
   privileged: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true
@@ -71,15 +71,15 @@ recommender:
   # Install PolicyExceptionDrafts on the giantswarm namespace
   destinationNamespace: policy-exceptions
   targetWorkloads:
-  - Deployment
-  - DaemonSet
-  - StatefulSet
-  - CronJob
+    - Deployment
+    - DaemonSet
+    - StatefulSet
+    - CronJob
   targetCategories:
-  - Pod Security Standards (Baseline)
-  - Pod Security Standards (Restricted)
-  - Pod Security Standards
+    - Pod Security Standards (Baseline)
+    - Pod Security Standards (Restricted)
+    - Pod Security Standards
   excludeNamespaces:
-  - kube-system
-  - giantswarm
+    - kube-system
+    - giantswarm
   createNamespace: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
