### PR TITLE
Remove wildcard from target names

### DIFF
--- a/internal/utils/automatedexception.go
+++ b/internal/utils/automatedexception.go
@@ -52,7 +52,7 @@ func generateTargets(resource corev1.ObjectReference) []gsPolicy.Target {
 
 	targets = append(targets, gsPolicy.Target{
 		Namespaces: []string{resource.Namespace},
-		Names:      []string{resource.Name + "*"},
+		Names:      []string{resource.Name},
 		Kind:       resource.Kind,
 	},
 	)


### PR DESCRIPTION
Removes the wildcard from targets names. This should be handlded on KPO to keep our resources cleaner