### PR TITLE
fix: build image from prebuilt binary to remove QEMU from multi-arch build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Build the container image from the pre-built binary produced by `architect/go-build` instead of compiling inside the image, removing QEMU emulation from the multi-arch build.
 - Resolve updated code linter findings.
 - Use AppVersion for image tag defaulting.
 - Migrate chart metadata annotations to OCI-compatible format.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,9 @@
-# Build the manager binary
-FROM golang:1.26 as builder
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-
-COPY internal/ internal/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+ARG TARGETOS
+ARG TARGETARCH
+COPY exception-recommender-${TARGETOS}-${TARGETARCH} /manager
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## What

Change the `Dockerfile` to build the container image from the pre-built binary produced by the `architect/go-build` CI job, instead of compiling Go inside the image. This mirrors the [starboard-exporter](https://github.com/giantswarm/starboard-exporter) pattern.

## Why

The multi-arch image build ran `go build` inside the container per target platform, so the **arm64 build ran under QEMU emulation** and exceeded CircleCI's 20-minute step timeout (the `go build -a` full-stdlib rebuild made it far worse). This failed the `push-to-registries` job on **every branch build**, including all open Renovate dependency PRs (#285, #289, #290).

`architect/go-build` already cross-compiles `exception-recommender-<os>-<arch>` **natively** (no emulation), so the Dockerfile only needs to `COPY` the matching binary into the distroless base. No in-container Go build, no QEMU.

## Verification

Reproduced locally against the Renovate kyverno branch:

- **Before** (in-container arm64 build under QEMU): the `go build` step ran >20 min and timed out.
- **After** (this change): native cross-compile amd64 ~5s / arm64 ~32s, multi-arch image build ~15s. Both resulting binaries verified as correct architectures (`x86-64` and `ARM aarch64`).

Once merged, rebasing the open Renovate PRs onto `main` will make their `push-to-registries` checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)